### PR TITLE
locale: Fix the translation of word `year`

### DIFF
--- a/src/locale/lang/id.js
+++ b/src/locale/lang/id.js
@@ -20,7 +20,7 @@ export default {
       nextYear: 'Next Year', // to be translated
       prevMonth: 'Previous Month', // to be translated
       nextMonth: 'Next Month', // to be translated
-      year: 'Tahun',
+      year: '',
       month1: 'Januari',
       month2: 'Februari',
       month3: 'Maret',


### PR DESCRIPTION
In Indonesia, people don't say date as `2019 Tahun November`. The correct format is month first, then the year. Example: `November 2019`. The `Tahun` is not needed.

And if it is possible, it's better to fix the word order of date. `November 2019` is correct, not `2019 November`.

![image](https://user-images.githubusercontent.com/7897384/70521995-3ad22780-1b7b-11ea-92e4-92b1a60b9931.png)
